### PR TITLE
Remove udev

### DIFF
--- a/com.stepmania.StepMania.json
+++ b/com.stepmania.StepMania.json
@@ -16,9 +16,8 @@
     ],
     "modules" : [
         "shared-modules/libmad/libmad.json",
-        "shared-modules/glu/glu-9.0.0.json",
+        "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",
-        "shared-modules/udev/udev-175.json",
         {
             "name" : "stepmania",
             "buildsystem" : "cmake-ninja",


### PR DESCRIPTION
Since gnome 3.34 udev is provided by runtime.

Also fix new glue module name.