### PR TITLE
Update runtime to Freedesktop 21.08

### DIFF
--- a/com.stepmania.StepMania.json
+++ b/com.stepmania.StepMania.json
@@ -1,15 +1,14 @@
 {
     "app-id" : "com.stepmania.StepMania",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.36",
-    "sdk" : "org.gnome.Sdk",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "21.08",
+    "sdk" : "org.freedesktop.Sdk",
     "command" : "stepmania",
     "finish-args" : [
         "--device=all",
         "--share=ipc",
         "--share=network",
         "--socket=pulseaudio",
-        "--socket=wayland",
         "--socket=x11",
         "--metadata=X-DConf=migrate-path=/com/stepmania/StepMania",
         "--persist=.stepmania-5.1"
@@ -26,11 +25,25 @@
                     "url" : "https://github.com/FFmpeg/FFmpeg/archive/n2.1.3.tar.gz",
                     "sha256" : "cfafef9c9fb2581ac234fc11da97c677e5a911db4e16b341ab724b7e6aa03b62"
                 }
+            ],
+            "modules": [
+                {
+                    "name": "yasm",
+                    "cleanup": [
+                        "*"
+                    ],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/yasm/yasm.git"
+                        }
+                    ]
+                }
             ]
         },
         {
             "name" : "stepmania",
-            "buildsystem" : "cmake",
+            "buildsystem" : "cmake-ninja",
             "config-opts" : [
                 "-DWITH_FFMPEG:BOOL=ON",
                 "-DWITH_SYSTEM_FFMPEG:BOOL=ON"


### PR DESCRIPTION
Build untested and flatpak-builder fails on certificates...

Close #16 
Close #15
Close #12 