### PR TITLE
Update the runtime version from 23.08 to 25.08, and more

### DIFF
--- a/com.stepmania.StepMania.json
+++ b/com.stepmania.StepMania.json
@@ -42,7 +42,6 @@
             "name" : "stepmania",
             "buildsystem" : "cmake-ninja",
             "config-opts" : [
-                "-DWITH_FULL_RELEASE=YES",
                 "-DWITH_PORTABLE_TOMCRYPT=NO",
                 "-DWITH_SYSTEM_FFMPEG=YES",
                 "-DWITH_SYSTEM_MAD=YES",
@@ -51,6 +50,7 @@
                 "-DWITH_SYSTEM_PNG=YES",
                 "-DWITH_SYSTEM_JSONCPP=YES",
                 "-DWITH_SYSTEM_ZLIB=YES",
+                "-DWITH_GTK3=NO",
                 "-Wno-dev",
                 "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             ],

--- a/com.stepmania.StepMania.json
+++ b/com.stepmania.StepMania.json
@@ -1,9 +1,11 @@
 {
     "app-id" : "com.stepmania.StepMania",
     "runtime" : "org.freedesktop.Platform",
-    "runtime-version" : "22.08",
+    "runtime-version" : "25.08",
     "sdk" : "org.freedesktop.Sdk",
     "command" : "stepmania",
+    "rename-desktop-file": "stepmania.desktop",
+    "rename-icon": "stepmania-ssc",
     "finish-args" : [
         "--device=all",
         "--share=ipc",
@@ -13,31 +15,26 @@
         "--metadata=X-DConf=migrate-path=/com/stepmania/StepMania",
         "--persist=.stepmania-5.1"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ],
     "modules" : [
         "shared-modules/libmad/libmad.json",
         "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",
         {
-            "name": "ffmpeg-2.1.3",
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://github.com/FFmpeg/FFmpeg/archive/n2.1.3.tar.gz",
-                    "sha256" : "cfafef9c9fb2581ac234fc11da97c677e5a911db4e16b341ab724b7e6aa03b62"
-                }
+            "name": "libjsoncpp",
+            "buildsystem": "meson",
+            "config-opts": [
+                "--buildtype=release",
+                "--default-library=shared"
             ],
-            "modules": [
+            "sources": [
                 {
-                    "name": "yasm",
-                    "cleanup": [
-                        "*"
-                    ],
-                    "sources": [
-                        {
-                            "type": "git",
-                            "url": "https://github.com/yasm/yasm.git"
-                        }
-                    ]
+                    "type": "archive",
+                    "url": "https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz",
+                    "sha256": "f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2"
                 }
             ]
         },
@@ -45,23 +42,43 @@
             "name" : "stepmania",
             "buildsystem" : "cmake-ninja",
             "config-opts" : [
-                "-DWITH_FFMPEG:BOOL=ON",
-                "-DWITH_SYSTEM_FFMPEG:BOOL=ON"
+                "-DWITH_FULL_RELEASE=YES",
+                "-DWITH_PORTABLE_TOMCRYPT=NO",
+                "-DWITH_SYSTEM_FFMPEG=YES",
+                "-DWITH_SYSTEM_MAD=YES",
+                "-DWITH_SYSTEM_OGG=YES",
+                "-DWITH_SYSTEM_JPEG=YES",
+                "-DWITH_SYSTEM_PNG=YES",
+                "-DWITH_SYSTEM_JSONCPP=YES",
+                "-DWITH_SYSTEM_ZLIB=YES",
+                "-Wno-dev",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             ],
             "post-install": [
                 "mkdir -p /app/bin/",
                 "ln -s /app/stepmania-5.1/stepmania /app/bin/stepmania",
-                "install -m644 -p -D icons/hicolor/256x256/apps/stepmania-ssc.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png",
-                "install -m644 -p -D icons/hicolor/scalable/apps/stepmania-ssc.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
-                "install -m644 -p -D stepmania.desktop /app/share/applications/${FLATPAK_ID}.desktop",
-                "install -m644 -p -D com.stepmania.StepMania.appdata.xml /app/share/appdata/${FLATPAK_ID}.appdata.xml",
-                "desktop-file-edit --set-icon=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop"
+                "install -Dm644 icons/hicolor/scalable/apps/stepmania-ssc.svg -t /app/share/icons/hicolor/scalable/apps/",
+                "install -Dm644 stepmania.desktop -t /app/share/applications/",
+                "install -Dm644 ${FLATPAK_ID}.appdata.xml -t /app/share/metainfo/",
+                "install -Dm644 Docs/Copying.MAD -t ${FLATPAK_DEST}/share/licenses/${FLATPAK_ID}/stepmania/",
+                "mv /app/stepmania-*/Docs/license-ext/ -t ${FLATPAK_DEST}/share/licenses/${FLATPAK_ID}/stepmania/"
             ],
             "sources" : [
                 {
-                    "type" : "archive",
-                    "url" : "https://github.com/stepmania/stepmania/archive/v5.1.0-b2.tar.gz",
-                    "sha256" : "2e311df9b661ba287b046ce377eb0b41e426b73e169841df99fc9fe2baa89310"
+                    "type" : "git",
+                    "url" : "https://github.com/stepmania/stepmania",
+                    "commit" : "d55acb1ba26f1c5b5e3048d6d6c0bd116625216f"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "patches/stepmania-fix-preview-crash.patch",
+                        "patches/stepmania-fix-ffmpeg-avcodec.patch",
+                        "patches/stepmania-remove-ffmpeg-asm-requirement.patch",
+                        "patches/stepmania-ffmeg-frame-num.patch",
+                        "patches/stepmania-long-musicwheel.patch",
+                        "patches/stepmania-ffmeg-avcodec_close-removal.patch"
+                    ]
                 },
                 {
                     "type": "file",

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": [ "i386", "x86_64" ]
+  "only-arches": ["x86_64"]
 }

--- a/patches/stepmania-ffmeg-avcodec_close-removal.patch
+++ b/patches/stepmania-ffmeg-avcodec_close-removal.patch
@@ -1,0 +1,22 @@
+diff --git a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+index 935ddf324b..cd6239e254 100644
+--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
++++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+@@ -506,7 +506,7 @@ RString MovieDecoder_FFMpeg::OpenCodec()
+ 
+ 	ASSERT( m_pStream != nullptr );
+ 	if( m_pStreamCodec->codec )
+-		avcodec::avcodec_close( m_pStreamCodec );
++		avcodec::avcodec_free_context( &m_pStreamCodec );
+ 
+ 	avcodec::AVCodec *pCodec = avcodec::avcodec_find_decoder( m_pStreamCodec->codec_id );
+ 	if( pCodec == nullptr )
+@@ -535,7 +535,7 @@ void MovieDecoder_FFMpeg::Close()
+ {
+ 	if( m_pStream && m_pStreamCodec->codec )
+ 	{
+-		avcodec::avcodec_close( m_pStreamCodec );
++		avcodec::avcodec_free_context( &m_pStreamCodec );
+ 		m_pStream = nullptr;
+ 	}
+ 

--- a/patches/stepmania-ffmeg-frame-num.patch
+++ b/patches/stepmania-ffmeg-frame-num.patch
@@ -1,0 +1,11 @@
+--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
++++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+@@ -273,7 +273,7 @@
+ 		bool bSkipThisFrame =
+ 			fTargetTime != -1 &&
+ 			GetTimestamp() + GetFrameDuration() < fTargetTime &&
+-			(m_pStreamCodec->frame_number % 2) == 0;
++			(m_pStreamCodec->frame_num % 2) == 0;
+ 
+ 		int iGotFrame;
+ 		int len;

--- a/patches/stepmania-fix-ffmpeg-avcodec.patch
+++ b/patches/stepmania-fix-ffmpeg-avcodec.patch
@@ -1,0 +1,45 @@
+From 3fef5ef60b7674d6431f4e1e4ba8c69b0c21c023 Mon Sep 17 00:00:00 2001
+From: Brad Smith <brad@comstyle.com>
+Date: Sat, 6 May 2023 22:26:07 -0400
+Subject: [PATCH] Fix building with newer FFmpeg
+
+This has been build tested against FFmpeg 4.4 and 6.0.
+---
+ src/arch/MovieTexture/MovieTexture_FFMpeg.cpp | 4 ++--
+ src/arch/MovieTexture/MovieTexture_FFMpeg.h   | 1 +
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+index 935ddf324b0..d4eed01d599 100644
+--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
++++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+@@ -405,7 +405,7 @@ void MovieTexture_FFMpeg::RegisterProtocols()
+ 		return;
+ 	Done = true;
+ 
+-#if !FF_API_NEXT
++#if LIBAVCODEC_VERSION_MAJOR < 58
+ 	avcodec::avcodec_register_all();
+ 	avcodec::av_register_all();
+ #endif
+@@ -508,7 +508,7 @@ RString MovieDecoder_FFMpeg::OpenCodec()
+ 	if( m_pStreamCodec->codec )
+ 		avcodec::avcodec_close( m_pStreamCodec );
+ 
+-	avcodec::AVCodec *pCodec = avcodec::avcodec_find_decoder( m_pStreamCodec->codec_id );
++	const avcodec::AVCodec *pCodec = avcodec::avcodec_find_decoder( m_pStreamCodec->codec_id );
+ 	if( pCodec == nullptr )
+ 		return ssprintf( "Couldn't find decoder %i", m_pStreamCodec->codec_id );
+ 
+diff --git a/src/arch/MovieTexture/MovieTexture_FFMpeg.h b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+index c092b765fc2..99f5ffcb1be 100644
+--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
++++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+@@ -13,6 +13,7 @@ namespace avcodec
+ 		#include <libavformat/avformat.h>
+ 		#include <libswscale/swscale.h>
+ 		#include <libavutil/pixdesc.h>
++		#include <libavcodec/avcodec.h>
+ 
+ 		#if LIBAVCODEC_VERSION_MAJOR >= 58
+ 		#define av_free_packet av_packet_unref

--- a/patches/stepmania-fix-preview-crash.patch
+++ b/patches/stepmania-fix-preview-crash.patch
@@ -1,0 +1,44 @@
+From e0d2a5182dcd855e181fffa086273460c553c7ff Mon Sep 17 00:00:00 2001
+From: mid-kid <esteve.varela@gmail.com>
+Date: Tue, 8 Nov 2022 21:37:28 +0100
+Subject: [PATCH] Fix crash on loading animated previews while using newer
+ ffmpeg
+
+0  0x00007ffff6ba7592 in avcodec_is_open () from /usr/lib64/libavcodec.so.58
+1  0x00007ffff6a83c0d in avcodec_close () from /usr/lib64/libavcodec.so.58
+2  0x00007ffff6fab5b9 in avcodec_free_context () from /usr/lib64/libavcodec.so.58
+3  0x0000555555a52075 in MovieDecoder_FFMpeg::Init (this=this@entry=0x55555695aae0) at <path>/stepmania/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp:167
+4  0x0000555555a528cc in MovieDecoder_FFMpeg::MovieDecoder_FFMpeg (this=0x55555695aae0) at <path>/stepmania/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp:120
+5  MovieTexture_FFMpeg::MovieTexture_FFMpeg (this=0x55555bd0b7f0, ID=...) at <path>/stepmania/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp:564
+6  0x0000555555a52a40 in RageMovieTextureDriver_FFMpeg::Create (this=this@entry=0x55555c5b8b60, ID=..., sError=...)
+   at <path>/stepmania/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp:570
+7  0x0000555555a4ece3 in RageMovieTexture::Create (ID=...) at <path>/stepmania/src/arch/MovieTexture/MovieTexture.cpp:113
+8  0x0000555555c32753 in RageTextureManager::LoadTextureInternal (this=<optimized out>, ID=...) at <path>/stepmania/src/RageTextureManager.cpp:168
+9  0x0000555555c32951 in RageTextureManager::LoadTexture (this=this@entry=0x55555a9aa8f0, ID=...) at <path>/stepmania/src/RageTextureManager.cpp:184
+10 0x000055555595f9e7 in Sprite::LoadFromTexture (this=0x55555b461900, ID=...) at <path>/stepmania/src/Sprite.cpp:362
+11 0x000055555595fb7a in Sprite::Load (this=0x55555b461900, ID=...) at <path>/stepmania/src/Sprite.cpp:176
+12 0x00005555559623d2 in LunaSprite::Load (p=0x55555b461900, L=0x5555567f9b50) at <path>/stepmania/src/Sprite.cpp:1132
+---
+ src/arch/MovieTexture/MovieTexture_FFMpeg.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+index 935ddf324b0..8a7abb601a7 100644
+--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
++++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+@@ -112,6 +112,7 @@ MovieDecoder_FFMpeg::MovieDecoder_FFMpeg()
+ 	m_swsctx = NULL;
+ 	m_avioContext = NULL;
+ 	m_buffer = NULL;
++	m_pStreamCodec = NULL;
+ 	m_fctx = nullptr;
+ 	m_pStream = nullptr;
+ 	m_iCurrentPacketOffset = -1;
+@@ -166,6 +167,7 @@ void MovieDecoder_FFMpeg::Init()
+ 	{
+ 		avcodec::avcodec_free_context(&m_pStreamCodec);
+ 	}
++	m_pStreamCodec = NULL;
+ #endif
+ }
+ 

--- a/patches/stepmania-long-musicwheel.patch
+++ b/patches/stepmania-long-musicwheel.patch
@@ -1,0 +1,12 @@
+--- stepmania/Themes/default/metrics.ini.orig	2025-01-09 12:31:34.793024559 +0100
++++ stepmania/Themes/default/metrics.ini	2025-01-09 12:31:59.576973086 +0100
+@@ -838,6 +838,9 @@
+ ShowRoulette=true
+ ShowRandom=true
+ 
++MostPlayedSongsToShow=500
++RecentSongsToShow=500
++
+ [MusicWheelItem]
+ Fallback=WheelItemBase
+ IconX=-186

--- a/patches/stepmania-remove-ffmpeg-asm-requirement.patch
+++ b/patches/stepmania-remove-ffmpeg-asm-requirement.patch
@@ -1,0 +1,11 @@
+--- a/StepmaniaCore.cmake
++++ b/StepmaniaCore.cmake
+@@ -443,7 +443,7 @@
+       )
+   endif()
+ 
+-  if(WITH_FFMPEG AND NOT YASM_FOUND AND NOT NASM_FOUND)
++  if(WITH_FFMPEG AND NOT WITH_SYSTEM_FFMPEG AND NOT YASM_FOUND AND NOT NASM_FOUND)
+     message(
+       "Neither NASM nor YASM were found. Please install at least one of them if you wish for ffmpeg support."
+       )


### PR DESCRIPTION
- Update the runtime version to 25.08
- Simplify the install commands
- A lot of patches from RPM Fusion repositories
- Update settings to match RPM Fusion version of the application
- Fix missing license files
- **Disable gtk3 to fix the following error**

```
StepMania5.1.0
Compiled 20260611 @ 13:26:22 +0300 (build d55acb1ba2)
Log starting 2026-06-11 13:29:48
Couldn't load driver gtk: dlopen(): /app/stepmania-5.1/GtkModule.so: undefined symbol: _Z13CreateSurfaceiiijjjj
Error: Couldn't open any loading windows.

```
